### PR TITLE
Fix the @ISA order in SPOPS::Exception

### DIFF
--- a/SPOPS/Exception.pm
+++ b/SPOPS/Exception.pm
@@ -3,7 +3,7 @@ package SPOPS::Exception;
 # $Id: Exception.pm,v 3.5 2004/06/02 00:48:21 lachoy Exp $
 
 use strict;
-use base qw( Class::Accessor Exporter );
+use base qw( Exporter Class::Accessor );
 use overload '""' => \&stringify;
 use Devel::StackTrace;
 use SPOPS::Error;


### PR DESCRIPTION
I believe the `spops_error` test failures are all the result of this ordering.